### PR TITLE
Fix: Handle i18n redirects for GitHub Pages SPA

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,13 +1,22 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=/" />
-    <script>
-      // Redirect to the index.html file
-      window.location.href = "/";
+    <title>Page Not Found - Redirecting...</title>
+    <script type="text/javascript">
+      // Get the current path and search query
+      var path = window.location.pathname;
+      var search = window.location.search;
+      var fullPath = path + search;
+
+      // Store the full path in sessionStorage
+      sessionStorage.setItem('spaRedirectPath', fullPath);
+
+      // Redirect to the root of the site.
+      // The Vue app will pick up the stored path from sessionStorage.
+      window.location.href = '/';
     </script>
   </head>
   <body>
-    <p>If you are not redirected, <a href="/">click here</a> to go to the homepage.</p>
+    <p>If you are not redirected automatically, please <a href="/">click here to go to the homepage</a>.</p>
   </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,6 +68,21 @@ const i18n = setupI18n({
 
 const router = setupRouter(i18n)
 
+// === Start of new code for handling redirect ===
+const savedPath = sessionStorage.getItem('spaRedirectPath')
+if (savedPath) {
+  sessionStorage.removeItem('spaRedirectPath')
+  // Wait for the router to be ready before replacing the path
+  // This ensures all navigation guards and async operations have a chance to complete
+  router.isReady().then(() => {
+    router.replace(savedPath)
+  }).catch(err => {
+    // Log any errors during router.replace, but don't block app mounting
+    console.error('Error during router.replace with savedPath:', err)
+  })
+}
+// === End of new code for handling redirect ===
+
 const app = createApp(App)
 
 app.use(i18n)


### PR DESCRIPTION
Modifies `404.html` to capture the originally requested path (including search parameters) and store it in `sessionStorage` before redirecting to the root of the application.

Updates `src/main.ts` to check for this `sessionStorage` item upon application load. If found, the Vue router navigates to the stored path, ensuring that direct links to i18n routes (e.g., /zhHant/some-page) work correctly when deployed to GitHub Pages.

This resolves the issue where accessing an i18n-specific URL directly would result in a GitHub 404 page or an incorrect redirect to the default language's homepage.

Modified by Google Jules